### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # machinshin
-public-todos
+public-todos / issues and calendar
+<iframe src="https://calendar.google.com/calendar/embed?height=768&wkst=1&bgcolor=%23F09300&ctz=America%2FLos_Angeles&title=Public%20Calendar%20-%20Events%2FAppointments&src=NDdmZDg0ZDJhNjc3NTZhMzRlN2IwNjMzZWM3Mzk1ZmRkNWQ0OGJhOWJhOGZiOGI0M2EyMmEzMzE0OTY3ZDIwYkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=dXRvNXQ3ZXNkajljczFyazE3MmtsMmpjdG9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=ZW4udXNhI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&src=aV8xNzMuMjI4Ljg1LjE4NSNzdW5yaXNlQGdyb3VwLnYuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&color=%23EF6C00&color=%23F09300&color=%233F51B5&color=%23cab238&color=%2333B679" style="border:solid 1px #777" width="1024" height="768" frameborder="0" scrolling="no"></iframe>
+
+
 This is for a public-self-tracking repo.
 
 Dunno where this idea came from, I found out about it from [StoneCypher](https://github.com/StoneCypher/StoneCypher) 


### PR DESCRIPTION
add a link to the google public calendar as an embedded link
closes #22 